### PR TITLE
ASP.NET Identity pages (frontend)

### DIFF
--- a/LMS.Blazor/Components/Account/Pages/ConfirmEmail.razor
+++ b/LMS.Blazor/Components/Account/Pages/ConfirmEmail.razor
@@ -10,8 +10,10 @@
 
 <PageTitle>Confirm email</PageTitle>
 
-<h1>Confirm email</h1>
-<StatusMessage Message="@statusMessage" />
+<div class="d-flex flex-column justify-content-center align-items-center min-vh-100">
+    <h1>Confirm email</h1>
+    <StatusMessage Message="@statusMessage" />
+</div>
 
 @code {
     private string? statusMessage;
@@ -29,7 +31,7 @@
     {
         if (UserId is null || Code is null)
         {
-            RedirectManager.RedirectTo("");
+           RedirectManager.RedirectTo("");
         }
 
         var user = await UserManager.FindByIdAsync(UserId);

--- a/LMS.Blazor/Components/Account/Pages/ConfirmEmailChange.razor
+++ b/LMS.Blazor/Components/Account/Pages/ConfirmEmailChange.razor
@@ -11,9 +11,10 @@
 
 <PageTitle>Confirm email change</PageTitle>
 
-<h1>Confirm email change</h1>
-
-<StatusMessage Message="@message" />
+<div class="d-flex flex-column justify-content-center align-items-center min-vh-100">
+    <h1>Confirm email change</h1>
+    <StatusMessage Message="@message" />
+</div>
 
 @code {
     private string? message;

--- a/LMS.Blazor/Components/Account/Pages/ForgotPassword.razor
+++ b/LMS.Blazor/Components/Account/Pages/ForgotPassword.razor
@@ -13,25 +13,26 @@
 
 <PageTitle>Forgot your password?</PageTitle>
 
-<h1>Forgot your password?</h1>
-<h2>Enter your email.</h2>
-<hr />
-<div class="row">
-    <div class="col-md-4">
-        <EditForm Model="Input" FormName="forgot-password" OnValidSubmit="OnValidSubmitAsync" method="post">
-            <DataAnnotationsValidator />
-            <ValidationSummary class="text-danger" role="alert" />
+<div class="d-flex flex-column justify-content-center align-items-center min-vh-100">
+    <h1>Forgot your password?</h1>
+    <h2>Enter your email.</h2>
+    <hr />
+    <div class="row justify-content-center" style="width: 100%">
+        <div class="col-md-6">
+            <EditForm Model="Input" FormName="forgot-password" OnValidSubmit="OnValidSubmitAsync" method="post">
+                <DataAnnotationsValidator />
+                <ValidationSummary class="text-danger" role="alert" />
 
-            <div class="form-floating mb-3">
-                <InputText @bind-Value="Input.Email" class="form-control" autocomplete="username" aria-required="true" placeholder="name@example.com" />
-                <label for="email" class="form-label">Email</label>
-                <ValidationMessage For="() => Input.Email" class="text-danger" />
-            </div>
-            <button type="submit" class="w-100 btn btn-lg btn-primary">Reset password</button>
-        </EditForm>
-     </div>
+                <div class="form-floating mb-3">
+                    <InputText @bind-Value="Input.Email" class="form-control" autocomplete="username" aria-required="true" placeholder="name@example.com" />
+                    <label for="email" class="form-label">Email</label>
+                    <ValidationMessage For="() => Input.Email" class="text-danger" />
+                </div>
+                <button type="submit" class="w-100 btn btn-lg btn-primary">Reset password</button>
+            </EditForm>
+        </div>
+    </div>
 </div>
-
 @code {
     [SupplyParameterFromForm]
     private InputModel Input { get; set; } = new();

--- a/LMS.Blazor/Components/Account/Pages/ForgotPasswordConfirmation.razor
+++ b/LMS.Blazor/Components/Account/Pages/ForgotPasswordConfirmation.razor
@@ -2,7 +2,9 @@
 
 <PageTitle>Forgot password confirmation</PageTitle>
 
-<h1>Forgot password confirmation</h1>
-<p>
-    Please check your email to reset your password.
-</p>
+<div class="d-flex flex-column justify-content-center align-items-center min-vh-100">
+    <h1>Forgot password confirmation</h1>
+    <p>
+        Please check your email to reset your password.
+    </p>
+</div>

--- a/LMS.Blazor/Components/Account/Pages/InvalidPasswordReset.razor
+++ b/LMS.Blazor/Components/Account/Pages/InvalidPasswordReset.razor
@@ -2,7 +2,9 @@
 
 <PageTitle>Invalid password reset</PageTitle>
 
-<h1>Invalid password reset</h1>
-<p>
-    The password reset link is invalid.
-</p>
+<div class="d-flex flex-column justify-content-center align-items-center min-vh-100">
+    <h1>Invalid password reset</h1>
+    <p>
+        The password reset link is invalid.
+    </p>
+</div>

--- a/LMS.Blazor/Components/Account/Pages/InvalidUser.razor
+++ b/LMS.Blazor/Components/Account/Pages/InvalidUser.razor
@@ -2,6 +2,8 @@
 
 <PageTitle>Invalid user</PageTitle>
 
-<h3>Invalid user</h3>
+<div class="d-flex flex-column justify-content-center align-items-center min-vh-100">
+    <h3>Invalid user</h3>
 
-<StatusMessage />
+    <StatusMessage />
+</div>

--- a/LMS.Blazor/Components/Account/Pages/Lockout.razor
+++ b/LMS.Blazor/Components/Account/Pages/Lockout.razor
@@ -2,7 +2,9 @@
 
 <PageTitle>Locked out</PageTitle>
 
-<header>
-    <h1 class="text-danger">Locked out</h1>
-    <p class="text-danger">This account has been locked out, please try again later.</p>
-</header>
+<div class="d-flex flex-column justify-content-center align-items-center min-vh-100">
+    <header>
+        <h1 class="text-danger">Locked out</h1>
+        <p class="text-danger">This account has been locked out, please try again later.</p>
+    </header>
+</div>

--- a/LMS.Blazor/Components/Account/Pages/LoginWith2fa.razor
+++ b/LMS.Blazor/Components/Account/Pages/LoginWith2fa.razor
@@ -10,38 +10,40 @@
 
 <PageTitle>Two-factor authentication</PageTitle>
 
-<h1>Two-factor authentication</h1>
-<hr />
-<StatusMessage Message="@message" />
-<p>Your login is protected with an authenticator app. Enter your authenticator code below.</p>
-<div class="row">
-    <div class="col-md-4">
-        <EditForm Model="Input" FormName="login-with-2fa" OnValidSubmit="OnValidSubmitAsync" method="post">
-            <input type="hidden" name="ReturnUrl" value="@ReturnUrl" />
-            <input type="hidden" name="RememberMe" value="@RememberMe" />
-            <DataAnnotationsValidator />
-            <ValidationSummary class="text-danger" role="alert" />
-            <div class="form-floating mb-3">
-                <InputText @bind-Value="Input.TwoFactorCode" class="form-control" autocomplete="off" />
-                <label for="two-factor-code" class="form-label">Authenticator code</label>
-                <ValidationMessage For="() => Input.TwoFactorCode" class="text-danger" />
-            </div>
-            <div class="checkbox mb-3">
-                <label for="remember-machine" class="form-label">
-                    <InputCheckbox @bind-Value="Input.RememberMachine" />
-                    Remember this machine
-                </label>
-            </div>
-            <div>
-                <button type="submit" class="w-100 btn btn-lg btn-primary">Log in</button>
-            </div>
-        </EditForm>
+<div class="d-flex flex-column justify-content-center align-items-center min-vh-100">
+    <h1>Two-factor authentication</h1>
+    <hr />
+    <StatusMessage Message="@message" />
+    <p>Your login is protected with an authenticator app. Enter your authenticator code below.</p>
+    <div class="row">
+        <div class="col-md-4" style="width: 100%">
+            <EditForm Model="Input" FormName="login-with-2fa" OnValidSubmit="OnValidSubmitAsync" method="post">
+                <input type="hidden" name="ReturnUrl" value="@ReturnUrl" />
+                <input type="hidden" name="RememberMe" value="@RememberMe" />
+                <DataAnnotationsValidator />
+                <ValidationSummary class="text-danger" role="alert" />
+                <div class="form-floating mb-3">
+                    <InputText @bind-Value="Input.TwoFactorCode" class="form-control" autocomplete="off" />
+                    <label for="two-factor-code" class="form-label">Authenticator code</label>
+                    <ValidationMessage For="() => Input.TwoFactorCode" class="text-danger" />
+                </div>
+                <div class="checkbox mb-3">
+                    <label for="remember-machine" class="form-label">
+                        <InputCheckbox @bind-Value="Input.RememberMachine" />
+                        Remember this machine
+                    </label>
+                </div>
+                <div>
+                    <button type="submit" class="w-100 btn btn-lg btn-primary">Log in</button>
+                </div>
+            </EditForm>
+        </div>
     </div>
+    <p>
+        Don't have access to your authenticator device? You can
+        <a href="Account/LoginWithRecoveryCode?ReturnUrl=@ReturnUrl">log in with a recovery code</a>.
+    </p>
 </div>
-<p>
-    Don't have access to your authenticator device? You can
-    <a href="Account/LoginWithRecoveryCode?ReturnUrl=@ReturnUrl">log in with a recovery code</a>.
-</p>
 
 @code {
     private string? message;
@@ -60,7 +62,7 @@
     {
         // Ensure the user has gone through the username & password screen first
         user = await SignInManager.GetTwoFactorAuthenticationUserAsync() ??
-            throw new InvalidOperationException("Unable to load two-factor authentication user.");
+           throw new InvalidOperationException("Unable to load two-factor authentication user.");
     }
 
     private async Task OnValidSubmitAsync()

--- a/LMS.Blazor/Components/Account/Pages/LoginWithRecoveryCode.razor
+++ b/LMS.Blazor/Components/Account/Pages/LoginWithRecoveryCode.razor
@@ -11,25 +11,27 @@
 
 <PageTitle>Recovery code verification</PageTitle>
 
-<h1>Recovery code verification</h1>
-<hr />
-<StatusMessage Message="@message" />
-<p>
-    You have requested to log in with a recovery code. This login will not be remembered until you provide
-    an authenticator app code at log in or disable 2FA and log in again.
-</p>
-<div class="row">
-    <div class="col-md-4">
-        <EditForm Model="Input" FormName="login-with-recovery-code" OnValidSubmit="OnValidSubmitAsync" method="post">
-            <DataAnnotationsValidator />
-            <ValidationSummary class="text-danger" role="alert" />
-            <div class="form-floating mb-3">
-                <InputText @bind-Value="Input.RecoveryCode" class="form-control" autocomplete="off" placeholder="RecoveryCode" />
-                <label for="recovery-code" class="form-label">Recovery Code</label>
-                <ValidationMessage For="() => Input.RecoveryCode" class="text-danger" />
-            </div>
-            <button type="submit" class="w-100 btn btn-lg btn-primary">Log in</button>
-        </EditForm>
+<div class="d-flex flex-column justify-content-center align-items-center min-vh-100">
+    <h1>Recovery code verification</h1>
+    <hr />
+    <StatusMessage Message="@message" />
+    <p class="text-center">
+        You have requested to log in with a recovery code. This login will not be remembered until you provide
+        an authenticator app code at log in or disable 2FA and log in again.
+    </p>
+    <div class="row">
+        <div class="col-md-4" style="width: 100%">
+            <EditForm Model="Input" FormName="login-with-recovery-code" OnValidSubmit="OnValidSubmitAsync" method="post">
+                <DataAnnotationsValidator />
+                <ValidationSummary class="text-danger" role="alert" />
+                <div class="form-floating mb-3">
+                    <InputText @bind-Value="Input.RecoveryCode" class="form-control" autocomplete="off" placeholder="RecoveryCode" />
+                    <label for="recovery-code" class="form-label">Recovery Code</label>
+                    <ValidationMessage For="() => Input.RecoveryCode" class="text-danger" />
+                </div>
+                <button type="submit" class="w-100 btn btn-lg btn-primary">Log in</button>
+            </EditForm>
+        </div>
     </div>
 </div>
 
@@ -46,8 +48,8 @@
     protected override async Task OnInitializedAsync()
     {
         // Ensure the user has gone through the username & password screen first
-        user = await SignInManager.GetTwoFactorAuthenticationUserAsync() ??
-            throw new InvalidOperationException("Unable to load two-factor authentication user.");
+        // user = await SignInManager.GetTwoFactorAuthenticationUserAsync() ??
+        // throw new InvalidOperationException("Unable to load two-factor authentication user.");
     }
 
     private async Task OnValidSubmitAsync()

--- a/LMS.Blazor/Components/Account/Pages/RegisterConfirmation.razor
+++ b/LMS.Blazor/Components/Account/Pages/RegisterConfirmation.razor
@@ -11,21 +11,24 @@
 
 <PageTitle>Register confirmation</PageTitle>
 
-<h1>Register confirmation</h1>
+<div class="d-flex flex-column justify-content-center align-items-center min-vh-100">
+    <h1>Register confirmation</h1>
 
-<StatusMessage Message="@statusMessage" />
+    <StatusMessage Message="@statusMessage" />
 
-@if (emailConfirmationLink is not null)
-{
-    <p>
-        This app does not currently have a real email sender registered, see <a href="https://aka.ms/aspaccountconf">these docs</a> for how to configure a real email sender.
-        Normally this would be emailed: <a href="@emailConfirmationLink">Click here to confirm your account</a>
-    </p>
-}
-else
-{
-    <p>Please check your email to confirm your account.</p>
-}
+    @if (emailConfirmationLink is not null)
+    {
+        <p>
+            This app does not currently have a real email sender registered, see <a href="https://aka.ms/aspaccountconf">these docs</a> for how to configure a real email sender.
+            Normally this would be emailed: <a href="@emailConfirmationLink">Click here to confirm your account</a>
+        </p>
+    }
+    else
+    {
+        <p>Please check your email to confirm your account.</p>
+    }
+
+</div>
 
 @code {
     private string? emailConfirmationLink;
@@ -47,7 +50,7 @@ else
             RedirectManager.RedirectTo("");
         }
 
-        var user = await UserManager.FindByEmailAsync(Email);
+       var user = await UserManager.FindByEmailAsync(Email);
         if (user is null)
         {
             HttpContext.Response.StatusCode = StatusCodes.Status404NotFound;

--- a/LMS.Blazor/Components/Account/Pages/ResendEmailConfirmation.razor
+++ b/LMS.Blazor/Components/Account/Pages/ResendEmailConfirmation.razor
@@ -13,12 +13,13 @@
 
 <PageTitle>Resend email confirmation</PageTitle>
 
+<div class="d-flex flex-column justify-content-center align-items-center min-vh-100">
 <h1>Resend email confirmation</h1>
 <h2>Enter your email.</h2>
 <hr />
 <StatusMessage Message="@message" />
 <div class="row">
-    <div class="col-md-4">
+    <div class="col-md-4" style="width: 100%">
         <EditForm Model="Input" FormName="resend-email-confirmation" OnValidSubmit="OnValidSubmitAsync" method="post">
             <DataAnnotationsValidator />
             <ValidationSummary class="text-danger" role="alert" />
@@ -30,6 +31,7 @@
             <button type="submit" class="w-100 btn btn-lg btn-primary">Resend</button>
         </EditForm>
     </div>
+</div>
 </div>
 
 @code {

--- a/LMS.Blazor/Components/Account/Pages/ResetPassword.razor
+++ b/LMS.Blazor/Components/Account/Pages/ResetPassword.razor
@@ -11,34 +11,36 @@
 
 <PageTitle>Reset password</PageTitle>
 
-<h1>Reset password</h1>
-<h2>Reset your password.</h2>
-<hr />
-<div class="row">
-    <div class="col-md-4">
-        <StatusMessage Message="@Message" />
-        <EditForm Model="Input" FormName="reset-password" OnValidSubmit="OnValidSubmitAsync" method="post">
-            <DataAnnotationsValidator />
-            <ValidationSummary class="text-danger" role="alert" />
+<div class="d-flex flex-column justify-content-center align-items-center min-vh-100">
+    <h1>Reset password</h1>
+    <h2>Reset your password.</h2>
+    <hr />
+    <div class="row">
+        <div class="col-md-4" style="width: 100%">
+            <StatusMessage Message="@Message" />
+            <EditForm Model="Input" FormName="reset-password" OnValidSubmit="OnValidSubmitAsync" method="post">
+                <DataAnnotationsValidator />
+                <ValidationSummary class="text-danger" role="alert" />
 
-            <input type="hidden" name="Input.Code" value="@Input.Code" />
-            <div class="form-floating mb-3">
-                <InputText @bind-Value="Input.Email" class="form-control" autocomplete="username" aria-required="true" placeholder="name@example.com" />
-                <label for="email" class="form-label">Email</label>
-                <ValidationMessage For="() => Input.Email" class="text-danger" />
-            </div>
-            <div class="form-floating mb-3">
-                <InputText type="password" @bind-Value="Input.Password" class="form-control" autocomplete="new-password" aria-required="true" placeholder="Please enter your password." />
-                <label for="password" class="form-label">Password</label>
-                <ValidationMessage For="() => Input.Password" class="text-danger" />
-            </div>
-            <div class="form-floating mb-3">
-                <InputText type="password" @bind-Value="Input.ConfirmPassword" class="form-control" autocomplete="new-password" aria-required="true" placeholder="Please confirm your password." />
-                <label for="confirm-password" class="form-label">Confirm password</label>
-                <ValidationMessage For="() => Input.ConfirmPassword" class="text-danger" />
-            </div>
-            <button type="submit" class="w-100 btn btn-lg btn-primary">Reset</button>
-        </EditForm>
+                <input type="hidden" name="Input.Code" value="@Input.Code" />
+                <div class="form-floating mb-3">
+                    <InputText @bind-Value="Input.Email" class="form-control" autocomplete="username" aria-required="true" placeholder="name@example.com" />
+                    <label for="email" class="form-label">Email</label>
+                    <ValidationMessage For="() => Input.Email" class="text-danger" />
+                </div>
+                <div class="form-floating mb-3">
+                    <InputText type="password" @bind-Value="Input.Password" class="form-control" autocomplete="new-password" aria-required="true" placeholder="Please enter your password." />
+                    <label for="password" class="form-label">Password</label>
+                    <ValidationMessage For="() => Input.Password" class="text-danger" />
+                </div>
+                <div class="form-floating mb-3">
+                    <InputText type="password" @bind-Value="Input.ConfirmPassword" class="form-control" autocomplete="new-password" aria-required="true" placeholder="Please confirm your password." />
+                    <label for="confirm-password" class="form-label">Confirm password</label>
+                    <ValidationMessage For="() => Input.ConfirmPassword" class="text-danger" />
+                </div>
+                <button type="submit" class="w-100 btn btn-lg btn-primary">Reset</button>
+            </EditForm>
+        </div>
     </div>
 </div>
 

--- a/LMS.Blazor/Components/Account/Pages/ResetPasswordConfirmation.razor
+++ b/LMS.Blazor/Components/Account/Pages/ResetPasswordConfirmation.razor
@@ -1,7 +1,9 @@
 ﻿@page "/Account/ResetPasswordConfirmation"
 <PageTitle>Reset password confirmation</PageTitle>
 
-<h1>Reset password confirmation</h1>
-<p>
-    Your password has been reset. Please <a href="Account/Login">click here to log in</a>.
-</p>
+<div class="d-flex flex-column justify-content-center align-items-center min-vh-100">
+    <h1>Reset password confirmation</h1>
+    <p>
+        Your password has been reset. Please <a href="Account/Login">click here to log in</a>.
+    </p>
+</div>


### PR DESCRIPTION
Add a container to all ASP.NET Identity pages to centralize the content. The original layout remains unchanged, with the container simply wrapping the existing structure for improved alignment.
All pages (except of Login and Register) looks like this:
<img width="726" alt="Screenshot_19" src="https://github.com/user-attachments/assets/26141df7-e2c2-4ac5-b1df-73d40399dd3f" />
<img width="645" alt="Screenshot_20" src="https://github.com/user-attachments/assets/465f16a1-61c1-4f97-bcc0-b154c803566f" />

